### PR TITLE
Fix version file URL property

### DIFF
--- a/Distribution/GameData/ShipManifest/ShipManifest.version
+++ b/Distribution/GameData/ShipManifest/ShipManifest.version
@@ -1,9 +1,8 @@
 {
   "NAME": "Ship Manifest",
-  "URL": "https://raw.githubusercontent.com/mwerle/ShipManifest/Distribution/GameData/ShipManifest/ShipManifest.version",
+  "URL": "https://github.com/mwerle/ShipManifest/raw/master/Distribution/GameData/ShipManifest/ShipManifest.version",
   "CHANGE_LOG_URL":"https://raw.githubusercontent.com/mwerle/ShipManifest/CHANGELOG.md",
-  "GITHUB":
-  {
+  "GITHUB": {
     "USERNAME":"mwerle",
     "REPOSITORY":"ShipManifest",
     "ALLOW_PRE_RELEASE":false


### PR DESCRIPTION
Same as a couple of previous PRs for other mods, the current URL is a 404, now it's fixed. I think in this case the problem was the branch name was missing.

Tagging @mwerle because not everyone has GitHub notifications enabled for pull requests.