### PR TITLE
Fix version file URL property and commas

### DIFF
--- a/Distribution/GameData/ShipManifest/ShipManifest.version
+++ b/Distribution/GameData/ShipManifest/ShipManifest.version
@@ -12,12 +12,12 @@
     "MAJOR": 6,
     "MINOR": 0,
     "PATCH": 1,
-    "BUILD": 0,
+    "BUILD": 0
   },
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 9,
-    "PATCH": 1,
+    "PATCH": 1
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,

--- a/Distribution/GameData/ShipManifest/ShipManifest.version
+++ b/Distribution/GameData/ShipManifest/ShipManifest.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Ship Manifest",
-  "URL": "https://raw.githubusercontent.com/mwerle/ShipManifest/Distribution/GameData/ShipManifest/ShipManifest.version",
+  "URL": "https://raw.githubusercontent.com/mwerle/ShipManifest/master/Distribution/GameData/ShipManifest/ShipManifest.version",
   "CHANGE_LOG_URL":"https://raw.githubusercontent.com/mwerle/ShipManifest/CHANGELOG.md",
   "GITHUB":
   {


### PR DESCRIPTION
Basically redoing what https://github.com/mwerle/ShipManifest/pull/1 already did, and additionally fix the commas.

https://github.com/mwerle/ShipManifest/commit/56e4b19f02e8c7e7a0f80eef401a7e1144515090 reverted the URL property fix of #1 / https://github.com/mwerle/ShipManifest/commit/59482ddddcfdfcd0dcbc0ec5e48f6c03255d3748

Please don't change the URL property anymore.
_If_ you move the version file, make sure you copy-paste from the browsers URL bar, instead of manually editing it.

Additionally, JSON dicts can't have a comma after the last property, this makes strict parsers fail.

---

If you want to catch errors like these _before_ releasing a new version, take a look at https://github.com/DasSkelett/AVC-VersionFileValidator
It can validate the version files for you. If you add it as GitHub Workflow to your repository, it runs on pushes to master (and pull requests), and GH sends you a notification if it fails.

Pinging @mwerle in case PR notifications are turned off.